### PR TITLE
cURL: Use System Certs

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=wiiu-curl
 pkgver=8.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Library for transferring data with URLs'
 arch=('any')
 url='https://curl.se/'
@@ -33,7 +33,8 @@ build() {
     --disable-pthreads \
     --disable-socketpair \
     --disable-ntlm-wb \
-    --with-mbedtls=${PORTLIBS_PREFIX}
+    --with-mbedtls=${PORTLIBS_PREFIX} \
+    --with-ca-path=/vol/storage_mlc01/sys/title/0005001b/10054000/content/scerts
 
   make -C lib
 }


### PR DESCRIPTION
## Description

cURL in my testing does not work without disabling peer verification at the moment. To remedy this, we can use the still working certificates on-console, for the time being. Per @GaryOderNichts's mention, which at most last until 2036 so we've got some time to figure out any other solutions we may want.

I've added `--with-ca-path` to the options pointing to the path on-console where these certificates are.

## Validation

I built this locally, installed it, and ran it with LÖVE Potion's lua-https cURL backend. Works perfectly.

