### PR TITLE
feat: enable websockets in curl

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=wiiu-curl
 pkgver=8.7.1
-pkgrel=2
+pkgrel=1
 pkgdesc='Library for transferring data with URLs'
 arch=('any')
 url='https://curl.se/'

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=wiiu-curl
 pkgver=8.7.1
-pkgrel=1
+pkgrel=3
 pkgdesc='Library for transferring data with URLs'
 arch=('any')
 url='https://curl.se/'

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -29,6 +29,7 @@ build() {
     --disable-pthreads \
     --disable-socketpair \
     --disable-ntlm-wb \
+    --enable-websockets \
     --with-mbedtls=${PORTLIBS_PREFIX} \
     --with-ca-path=/vol/storage_mlc01/sys/title/0005001b/10054000/content/scerts
 


### PR DESCRIPTION
This only adds 9 kilobytes to the wiiu-curl package which is very little compared to the original 547 kilobytes before hand. Adding 9 kilobytes should not have very much effect on many applications. If you want I can turn this into it's own package.